### PR TITLE
fix: relax oc-changelog gate for release-please PRs

### DIFF
--- a/.github/workflows/oc-changelog.yml
+++ b/.github/workflows/oc-changelog.yml
@@ -12,8 +12,6 @@ jobs:
   oc-zen-free:
     if: |
       github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.fork == false &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'release-please--')
     uses: ./.github/workflows/oc-zen-free.yml
 


### PR DESCRIPTION
Relaxes the oc-changelog workflow gate by removing:
- head.repo.fork check
- head.repo.full_name check

This should allow oc-changelog to run on release-please created PRs.