### PR TITLE
fix: add GITHUB_TOKEN to oc-changelog for write permissions

### DIFF
--- a/.github/workflows/oc-changelog.yml
+++ b/.github/workflows/oc-changelog.yml
@@ -34,6 +34,7 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         with:
           model: ${{ needs.oc-zen-free.outputs.model }}
           prompt: |


### PR DESCRIPTION
Adds GITHUB_TOKEN environment variable using RELEASE_PLEASE_TOKEN secret so the OpenCode agent can write changes to CHANGELOG.md and update PR descriptions.