### PR TITLE
fix: prevent release-please from creating immutable releases

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
+  "skip-github-release": true,
   "packages": {
     ".": {
       "release-type": "node",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
+      - '*-v*'
 
 jobs:
   publish:
@@ -38,7 +40,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} ./*.tgz
+          # Create the release if it doesn't exist (release-please skips this with skip-github-release: true)
+          gh release create ${{ github.ref_name }} --title "${{ github.ref_name }}" --notes "See CHANGELOG.md for details" || true
+          # Upload the tarball
+          gh release upload ${{ github.ref_name }} ./*.tgz --clobber
 
       # npm still needed for trusted publishing, see:
       # https://github.com/oven-sh/bun/issues/15601
@@ -52,4 +57,6 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance


### PR DESCRIPTION
Fixes the release workflow failure where assets couldn't be uploaded to immutable releases.

Changes:
- Add skip-github-release to release-please config so it doesn't create/publish releases
- Change release workflow trigger from release.published to tag pushes
- Create GitHub release in workflow if it doesn't exist, then upload assets
- Add NODE_AUTH_TOKEN environment variable for npm publish

This ensures the release workflow controls the entire release process: building, attesting, creating the GitHub release, uploading assets, and publishing to npm.