### PR TITLE
fix: add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - 'v*'
       - '*-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.3.0)'
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -16,6 +22,8 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -40,10 +48,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Determine the tag name from trigger type
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
           # Create the release if it doesn't exist (release-please skips this with skip-github-release: true)
-          gh release create ${{ github.ref_name }} --title "${{ github.ref_name }}" --notes "See CHANGELOG.md for details" || true
+          gh release create "$TAG" --title "$TAG" --notes "See CHANGELOG.md for details" || true
           # Upload the tarball
-          gh release upload ${{ github.ref_name }} ./*.tgz --clobber
+          gh release upload "$TAG" ./*.tgz --clobber
 
       # npm still needed for trusted publishing, see:
       # https://github.com/oven-sh/bun/issues/15601


### PR DESCRIPTION
Adds ability to manually trigger the release workflow with a specific tag, useful when the automated tag push is blocked by repository rules.